### PR TITLE
feat: enhance external client configuration and testing

### DIFF
--- a/src/Dev.ExternalClients/ExternalClientServiceCollectionExtensions.cs
+++ b/src/Dev.ExternalClients/ExternalClientServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Dev.ExternalClients;
@@ -21,19 +22,62 @@ public static class ExternalClientServiceCollectionExtensions
         where TClient : class
         where TImplementation : class, TClient
     {
-        services.AddOptions<ExternalClientOptions>(typeof(TImplementation).Name)
-            .Configure(configureOptions)
-            .ValidateDataAnnotations()
-            .ValidateOnStart();
+        var externalClientName = typeof(TImplementation).Name;
 
-        services.AddHttpClient<TClient, TImplementation>((serviceProvider, client) =>
+        services.AddExternalClientOptions(externalClientName)
+            .Configure(configureOptions);
+
+        services.AddExternalClient<TClient, TImplementation>(externalClientName);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds and configures an external HTTP client using options from the configuration.
+    /// </summary>
+    /// <typeparam name="TClient">The type of the client interface.</typeparam>
+    /// <typeparam name="TImplementation">The type of the client implementation.</typeparam>
+    /// <param name="services">The service collection to add the client to.</param>
+    /// <param name="configuration">The configuration instance to read the options from.</param>
+    /// <returns>The service collection with the configured client added.</returns>
+    public static IServiceCollection AddExternalClient<TClient, TImplementation>(
+        this IServiceCollection services, IConfiguration configuration)
+        where TClient : class
+        where TImplementation : class, TClient
+    {
+        var externalClientName = typeof(TImplementation).Name;
+
+        services.AddExternalClientOptions(externalClientName)
+            .Bind(configuration.GetSection(externalClientName));
+
+        services.AddExternalClient<TClient, TImplementation>(externalClientName);
+
+        return services;
+    }
+
+    private static IHttpClientBuilder AddExternalClient<TClient, TImplementation>(
+        this IServiceCollection services, string externalClientName)
+        where TClient : class
+        where TImplementation : class, TClient
+    {
+        var builder = services.AddHttpClient<TClient, TImplementation>(externalClientName, (serviceProvider, client) =>
         {
             var options = serviceProvider.GetRequiredService<
-                IOptionsSnapshot<ExternalClientOptions>>().Get(typeof(TImplementation).Name);
+                IOptionsSnapshot<ExternalClientOptions>>().Get(externalClientName);
 
             options.ApplyTo(client);
         });
 
-        return services;
+        return builder;
+    }
+
+    private static OptionsBuilder<ExternalClientOptions> AddExternalClientOptions(
+        this IServiceCollection services, string externalClientName)
+    {
+        var optionsBuilder = services.AddOptions<ExternalClientOptions>(externalClientName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        return optionsBuilder;
     }
 }

--- a/tests/Dev.ExternalClients.Tests.Unit/ExternalClientServiceCollectionExtensionsTests.cs
+++ b/tests/Dev.ExternalClients.Tests.Unit/ExternalClientServiceCollectionExtensionsTests.cs
@@ -1,129 +1,176 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Dev.ExternalClients.Tests.Unit;
 
 public class ExternalClientServiceCollectionExtensionsTests
 {
-    public interface ITestClient
-    {
-        HttpClient HttpClient { get; }
-    }
-
-    public class TestClient(HttpClient httpClient) : ITestClient
-    {
-        public HttpClient HttpClient { get; } = httpClient;
-    }
-
-    public interface IAnotherTestClient
-    {
-        HttpClient HttpClient { get; }
-    }
-
-    public class AnotherTestClient(HttpClient httpClient) : IAnotherTestClient
-    {
-        public HttpClient HttpClient { get; } = httpClient;
-    }
-
     [Fact]
-    public void AddExternalClient_ShouldConfigureHttpClientWithOptions()
+    public void AddExternalClient_WithActionConfiguration_ConfiguresHttpClientProperly()
     {
         // Arrange
         var services = new ServiceCollection();
-        services.AddExternalClient<ITestClient, TestClient>(options =>
+        services.AddExternalClient<IActionTestClient, ActionTestClient>(opts =>
         {
-            options.BaseAddress = "https://api.example.com";
-            options.Timeout = TimeSpan.FromSeconds(5);
-            options.DefaultRequestHeaders = new Dictionary<string, string>
+            opts.BaseAddress = "http://example.com";
+            opts.Timeout = TimeSpan.FromSeconds(5);
+            opts.DefaultRequestHeaders = new Dictionary<string, string>
             {
-                    { "Authorization", "Bearer token" },
-                    { "Accept", "application/json" }
+                { "Test-Header", "Value" }
+            };
+        });
+        var provider = services.BuildServiceProvider();
+
+        // Act
+        var client = provider.GetRequiredService<IActionTestClient>() as ActionTestClient;
+
+        // Assert
+        Assert.NotNull(client);
+        Assert.Equal(new Uri("http://example.com"), client.HttpClient.BaseAddress);
+        Assert.Equal(TimeSpan.FromSeconds(5), client.HttpClient.Timeout);
+        Assert.True(client.HttpClient.DefaultRequestHeaders.Contains("Test-Header"));
+        Assert.Equal("Value", client.HttpClient.DefaultRequestHeaders.GetValues("Test-Header").First());
+    }
+
+    [Fact]
+    public void AddExternalClient_WithConfigurationBinding_ConfiguresHttpClientProperly()
+    {
+        // Arrange
+        var inMemorySettings = new Dictionary<string, string?>
+        {
+            { "ConfigTestClient:BaseAddress", "http://config.com" },
+            { "ConfigTestClient:Timeout", "00:00:05" }
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings)
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddExternalClient<IConfigTestClient, ConfigTestClient>(configuration);
+        var provider = services.BuildServiceProvider();
+
+        // Act
+        var client = provider.GetRequiredService<IConfigTestClient>() as ConfigTestClient;
+
+        // Assert
+        Assert.NotNull(client);
+        Assert.Equal(new Uri("http://config.com"), client.HttpClient.BaseAddress);
+        Assert.Equal(TimeSpan.FromSeconds(5), client.HttpClient.Timeout);
+    }
+
+    [Fact]
+    public void AddExternalClient_MultipleRegistrationsForSameClient_LastConfigurationOverrides()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // First registration with initial settings
+        services.AddExternalClient<IMultiRegistrationClient, MultiRegistrationClient>(opts =>
+        {
+            opts.BaseAddress = "http://first.com";
+            opts.Timeout = TimeSpan.FromSeconds(5);
+            opts.DefaultRequestHeaders = new Dictionary<string, string>
+            {
+                { "X-First", "Value1" }
             };
         });
 
-        var serviceProvider = services.BuildServiceProvider();
-        var client = serviceProvider.GetRequiredService<ITestClient>();
+        // Second registration that overrides some properties
+        services.AddExternalClient<IMultiRegistrationClient, MultiRegistrationClient>(opts =>
+        {
+            // BaseAddress remains from the first registration.
+            opts.Timeout = TimeSpan.FromSeconds(7);
+            opts.DefaultRequestHeaders = new Dictionary<string, string>
+            {
+                { "X-Second", "Value2" }
+            };
+        });
+
+        var provider = services.BuildServiceProvider();
 
         // Act
-        var httpClient = client.HttpClient;
+        var client = provider.GetRequiredService<IMultiRegistrationClient>() as MultiRegistrationClient;
 
         // Assert
-        Assert.Equal(new Uri("https://api.example.com"), httpClient.BaseAddress);
-        Assert.Equal(TimeSpan.FromSeconds(5), httpClient.Timeout);
-        Assert.True(httpClient.DefaultRequestHeaders.Contains("Authorization"));
-        Assert.True(httpClient.DefaultRequestHeaders.Contains("Accept"));
-        Assert.Equal("Bearer token", httpClient.DefaultRequestHeaders.GetValues("Authorization").First());
-        Assert.Equal("application/json", httpClient.DefaultRequestHeaders.GetValues("Accept").First());
+        Assert.NotNull(client);
+        // Expect the BaseAddress from the first registration.
+        Assert.Equal(new Uri("http://first.com"), client.HttpClient.BaseAddress);
+        // Expect the Timeout from the second registration.
+        Assert.Equal(TimeSpan.FromSeconds(7), client.HttpClient.Timeout);
+        // Only the header from the second registration should be applied.
+        Assert.False(client.HttpClient.DefaultRequestHeaders.Contains("X-First"));
+        Assert.True(client.HttpClient.DefaultRequestHeaders.Contains("X-Second"));
     }
 
     [Fact]
-    public void AddExternalClient_ShouldThrowExceptionForInvalidOptions()
+    public void AddExternalClient_DifferentClients_HaveIndependentConfigurations()
     {
         // Arrange
         var services = new ServiceCollection();
-        services.AddExternalClient<ITestClient, TestClient>(options =>
+
+        services.AddExternalClient<IDiffClient1, DiffClient1>(opts =>
         {
-            options.BaseAddress = "invalid-url";
-            options.Timeout = TimeSpan.FromSeconds(5);
+            opts.BaseAddress = "http://client1.com";
+            opts.Timeout = TimeSpan.FromSeconds(5);
         });
 
-        // Act & Assert
-        var serviceProvider = services.BuildServiceProvider();
-        Assert.Throws<OptionsValidationException>(() => serviceProvider.GetRequiredService<ITestClient>());
+        services.AddExternalClient<IDiffClient2, DiffClient2>(opts =>
+        {
+            opts.BaseAddress = "http://client2.com";
+            opts.Timeout = TimeSpan.FromSeconds(8);
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        // Act
+        var client1 = provider.GetRequiredService<IDiffClient1>() as DiffClient1;
+        var client2 = provider.GetRequiredService<IDiffClient2>() as DiffClient2;
+
+        // Assert
+        Assert.NotNull(client1);
+        Assert.Equal(new Uri("http://client1.com"), client1.HttpClient.BaseAddress);
+        Assert.Equal(TimeSpan.FromSeconds(5), client1.HttpClient.Timeout);
+
+        Assert.NotNull(client2);
+        Assert.Equal(new Uri("http://client2.com"), client2.HttpClient.BaseAddress);
+        Assert.Equal(TimeSpan.FromSeconds(8), client2.HttpClient.Timeout);
     }
 
     [Fact]
-    public void AddExternalClient_ShouldConfigureMultipleClientsIndependently()
+    public void AddExternalClient_SameInterfaceDifferentImplementations_ResolvesAllClients()
     {
         // Arrange
         var services = new ServiceCollection();
-        services.AddExternalClient<ITestClient, TestClient>(options =>
+
+        services.AddExternalClient<ICommonClient, CommonClientA>(opts =>
         {
-            options.BaseAddress = "https://api.example.com";
-            options.Timeout = TimeSpan.FromSeconds(5);
+            opts.BaseAddress = "http://clientA.com";
+            opts.Timeout = TimeSpan.FromSeconds(5);
         });
 
-        services.AddExternalClient<IAnotherTestClient, AnotherTestClient>(options =>
+        services.AddExternalClient<ICommonClient, CommonClientB>(opts =>
         {
-            options.BaseAddress = "https://api.anotherexample.com";
-            options.Timeout = TimeSpan.FromSeconds(10);
+            opts.BaseAddress = "http://clientB.com";
+            opts.Timeout = TimeSpan.FromSeconds(8);
         });
 
-        var serviceProvider = services.BuildServiceProvider();
-        var testClient = serviceProvider.GetRequiredService<ITestClient>();
-        var anotherTestClient = serviceProvider.GetRequiredService<IAnotherTestClient>();
+        var provider = services.BuildServiceProvider();
 
         // Act
-        var testHttpClient = testClient.HttpClient;
-        var anotherTestHttpClient = anotherTestClient.HttpClient;
+        var clients = provider.GetServices<ICommonClient>().ToList();
 
         // Assert
-        Assert.Equal(new Uri("https://api.example.com"), testHttpClient.BaseAddress);
-        Assert.Equal(TimeSpan.FromSeconds(5), testHttpClient.Timeout);
+        Assert.Equal(2, clients.Count);
+        var clientA = clients.OfType<CommonClientA>().FirstOrDefault();
+        var clientB = clients.OfType<CommonClientB>().FirstOrDefault();
 
-        Assert.Equal(new Uri("https://api.anotherexample.com"), anotherTestHttpClient.BaseAddress);
-        Assert.Equal(TimeSpan.FromSeconds(10), anotherTestHttpClient.Timeout);
-    }
+        Assert.NotNull(clientA);
+        Assert.Equal(new Uri("http://clientA.com"), clientA.HttpClient.BaseAddress);
+        Assert.Equal(TimeSpan.FromSeconds(5), clientA.HttpClient.Timeout);
 
-    [Fact]
-    public void AddExternalClient_ShouldApplyDefaultValues()
-    {
-        // Arrange
-        var services = new ServiceCollection();
-        services.AddExternalClient<ITestClient, TestClient>(options =>
-        {
-            options.BaseAddress = "https://api.example.com";
-        });
-
-        var serviceProvider = services.BuildServiceProvider();
-        var client = serviceProvider.GetRequiredService<ITestClient>();
-
-        // Act
-        var httpClient = client.HttpClient;
-
-        // Assert
-        Assert.Equal(new Uri("https://api.example.com"), httpClient.BaseAddress);
-        Assert.Equal(TimeSpan.FromSeconds(10), httpClient.Timeout); // Default timeout
+        Assert.NotNull(clientB);
+        Assert.Equal(new Uri("http://clientB.com"), clientB.HttpClient.BaseAddress);
+        Assert.Equal(TimeSpan.FromSeconds(8), clientB.HttpClient.Timeout);
     }
 }

--- a/tests/Dev.ExternalClients.Tests.Unit/TestClients.cs
+++ b/tests/Dev.ExternalClients.Tests.Unit/TestClients.cs
@@ -1,0 +1,66 @@
+﻿namespace Dev.ExternalClients.Tests.Unit;
+
+// Helper types for the tests
+
+// For action-based configuration test
+public interface IActionTestClient
+{
+    HttpClient HttpClient { get; }
+}
+public class ActionTestClient(HttpClient client) : IActionTestClient
+{
+    public HttpClient HttpClient { get; } = client;
+}
+
+// For configuration-based binding test
+public interface IConfigTestClient
+{
+    HttpClient HttpClient { get; }
+}
+public class ConfigTestClient(HttpClient client) : IConfigTestClient
+{
+    public HttpClient HttpClient { get; } = client;
+}
+
+// For multiple registrations test (same TClient/TImplementation)
+public interface IMultiRegistrationClient
+{
+    HttpClient HttpClient { get; }
+}
+public class MultiRegistrationClient(HttpClient client) : IMultiRegistrationClient
+{
+    public HttpClient HttpClient { get; } = client;
+}
+
+// For different external clients test
+public interface IDiffClient1
+{
+    HttpClient HttpClient { get; }
+}
+public class DiffClient1(HttpClient client) : IDiffClient1
+{
+    public HttpClient HttpClient { get; } = client;
+}
+
+public interface IDiffClient2
+{
+    HttpClient HttpClient { get; }
+}
+public class DiffClient2(HttpClient client) : IDiffClient2
+{
+    public HttpClient HttpClient { get; } = client;
+}
+
+// For same interface with different implementations test
+public interface ICommonClient
+{
+    HttpClient HttpClient { get; }
+}
+public class CommonClientA(HttpClient client) : ICommonClient
+{
+    public HttpClient HttpClient { get; } = client;
+}
+public class CommonClientB(HttpClient client) : ICommonClient
+{
+    public HttpClient HttpClient { get; } = client;
+}


### PR DESCRIPTION
Improve the configuration of external HTTP clients in `ExternalClientServiceCollectionExtensions.cs` by adding methods to bind settings from `IConfiguration` and streamline client registration. The `AddExternalClient` method now supports both action-based and configuration-based setups, with a new private method `AddExternalClientOptions` for options registration.

Update tests in `ExternalClientServiceCollectionExtensionsTests.cs` to validate both client setup methods and ensure correct configuration of HTTP clients.

Introduce `TestClients.cs` to define various test client interfaces and implementations, facilitating comprehensive testing of the external client registration logic.

Related issues: #3